### PR TITLE
:recycle: refactor: Passando a lógica de crud e das funcionalidades da cobrança do controller para o service

### DIFF
--- a/src/main/java/br/com/paymentmanager/controller/CobrancaController.java
+++ b/src/main/java/br/com/paymentmanager/controller/CobrancaController.java
@@ -3,17 +3,11 @@ package br.com.paymentmanager.controller;
 
 import br.com.paymentmanager.dto.CobrancaDto;
 import br.com.paymentmanager.form.CobrancaForm;
-import br.com.paymentmanager.mapper.CobrancaMapper;
-import br.com.paymentmanager.model.Cobranca;
-import br.com.paymentmanager.model.Divida;
-import br.com.paymentmanager.repository.CobrancaRepository;
-import br.com.paymentmanager.repository.DividaRepository;
+import br.com.paymentmanager.service.CobrancaService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
@@ -24,28 +18,19 @@ import java.util.List;
 public class CobrancaController {
 
     @Autowired
-    private CobrancaRepository cobrancaRepository;
-
-    @Autowired
-    private DividaRepository dividaRepository;
+    private CobrancaService cobrancaService;
 
     @GetMapping
-    public List<CobrancaDto> listar() {
-        List<Cobranca> cobrancas = cobrancaRepository.findAll();
-        return CobrancaDto.converter(cobrancas);
+    public ResponseEntity<List<CobrancaDto>> listar() {
+        return ResponseEntity.ok().body(cobrancaService.listar());
     }
 
     @PostMapping
     public ResponseEntity<CobrancaDto> cadastrar(@RequestBody @Valid CobrancaForm form, UriComponentsBuilder uriBuilder) {
-        Divida divida = dividaRepository.findById(form.getIdDivida())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "id da dívida não encontrado"));
+        CobrancaDto cobrancaDto = cobrancaService.cadastrar(form);
 
-        Cobranca cobranca = new CobrancaMapper().cadastrar(form, cobrancaRepository, divida);
-
-        cobrancaRepository.save(cobranca);
-
-        URI uri = uriBuilder.path("/api/cobrancas/{id}").buildAndExpand(cobranca.getId()).toUri();
-        return ResponseEntity.created(uri).body(new CobrancaDto(cobranca));
+        URI uri = uriBuilder.path("/api/cobrancas/{id}").buildAndExpand(cobrancaDto.getId()).toUri();
+        return ResponseEntity.created(uri).body(cobrancaDto);
     }
 
 }

--- a/src/main/java/br/com/paymentmanager/dto/CobrancaDto.java
+++ b/src/main/java/br/com/paymentmanager/dto/CobrancaDto.java
@@ -6,8 +6,6 @@ import br.com.paymentmanager.model.TipoAcordo;
 import br.com.paymentmanager.model.TipoAgente;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class CobrancaDto {
 
@@ -94,7 +92,4 @@ public class CobrancaDto {
         return idDivida;
     }
 
-    public static List<CobrancaDto> converter(List<Cobranca> cobrancas) {
-        return cobrancas.stream().map(CobrancaDto::new).collect(Collectors.toList());
-    }
 }

--- a/src/main/java/br/com/paymentmanager/dto/CodigosDosEnviosDto.java
+++ b/src/main/java/br/com/paymentmanager/dto/CodigosDosEnviosDto.java
@@ -4,9 +4,6 @@ import br.com.paymentmanager.projection.CodigosDosEnvios;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Getter
 @AllArgsConstructor
 public class CodigosDosEnviosDto {
@@ -19,7 +16,4 @@ public class CodigosDosEnviosDto {
         this.nomeArquivo = codigos.getNomeArquivo();
     }
 
-    public static List<CodigosDosEnviosDto> converter(List<CodigosDosEnvios> codigosDasCobrancas) {
-        return codigosDasCobrancas.stream().map(CodigosDosEnviosDto::new).collect(Collectors.toList());
-    }
 }

--- a/src/main/java/br/com/paymentmanager/dto/DividaComCpfDto.java
+++ b/src/main/java/br/com/paymentmanager/dto/DividaComCpfDto.java
@@ -2,7 +2,6 @@ package br.com.paymentmanager.dto;
 
 import br.com.paymentmanager.model.Divida;
 import br.com.paymentmanager.model.StatusDivida;
-import org.springframework.data.domain.Page;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -59,10 +58,6 @@ public class DividaComCpfDto {
 
     public String getCpf() {
         return cpf;
-    }
-
-    public static Page<DividaComCpfDto> converter(Page<Divida> dividas) {
-        return dividas.map(DividaComCpfDto::new);
     }
 
 }

--- a/src/main/java/br/com/paymentmanager/dto/DividaDto.java
+++ b/src/main/java/br/com/paymentmanager/dto/DividaDto.java
@@ -5,8 +5,6 @@ import br.com.paymentmanager.model.StatusDivida;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class DividaDto {
 
@@ -65,7 +63,4 @@ public class DividaDto {
         return idCliente;
     }
 
-    public static List<DividaDto> converter(List<Divida> dividas){
-        return dividas.stream().map(DividaDto::new).collect(Collectors.toList());
-    }
 }

--- a/src/main/java/br/com/paymentmanager/dto/DividaWebDto.java
+++ b/src/main/java/br/com/paymentmanager/dto/DividaWebDto.java
@@ -5,8 +5,6 @@ import br.com.paymentmanager.model.StatusDivida;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class DividaWebDto {
 
@@ -48,7 +46,4 @@ public class DividaWebDto {
         return idCliente;
     }
 
-    public static List<DividaWebDto> converter(List<Divida> dividas){
-        return dividas.stream().map(DividaWebDto::new).collect(Collectors.toList());
-    }
 }

--- a/src/main/java/br/com/paymentmanager/service/CobrancaService.java
+++ b/src/main/java/br/com/paymentmanager/service/CobrancaService.java
@@ -1,0 +1,48 @@
+package br.com.paymentmanager.service;
+
+import br.com.paymentmanager.dto.CobrancaDto;
+import br.com.paymentmanager.form.CobrancaForm;
+import br.com.paymentmanager.mapper.CobrancaMapper;
+import br.com.paymentmanager.model.Cobranca;
+import br.com.paymentmanager.model.Divida;
+import br.com.paymentmanager.repository.CobrancaRepository;
+import br.com.paymentmanager.repository.DividaRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CobrancaService {
+
+    private final CobrancaRepository cobrancaRepository;
+
+    private final DividaRepository dividaRepository;
+
+    private final DividaService dividaService;
+
+    public CobrancaService(CobrancaRepository cobrancaRepository, DividaRepository dividaRepository, DividaService dividaService) {
+        this.cobrancaRepository = cobrancaRepository;
+        this.dividaRepository = dividaRepository;
+        this.dividaService = dividaService;
+    }
+
+    public List<CobrancaDto> listar() {
+        List<Cobranca> cobrancas = cobrancaRepository.findAll();
+        return cobrancas.stream().map(CobrancaDto::new).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public CobrancaDto cadastrar(CobrancaForm form) {
+        Divida divida = dividaService.buscarDivida(form.getIdDivida());
+        Cobranca cobranca = new CobrancaMapper().cadastrar(form, this.cobrancaRepository, divida);
+
+        cobrancaRepository.save(cobranca);
+
+        return new CobrancaDto(cobranca);
+    }
+
+
+
+}

--- a/src/main/java/br/com/paymentmanager/service/DividaService.java
+++ b/src/main/java/br/com/paymentmanager/service/DividaService.java
@@ -54,7 +54,7 @@ public class DividaService {
         dividaRepository.deleteById(divida.getId());
     }
 
-    private Divida buscarDivida(Long id) {
+    protected Divida buscarDivida(Long id) {
         return this.dividaRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "id da divida não encontrado"));
     }

--- a/src/main/java/br/com/paymentmanager/service/EnvioBoletoService.java
+++ b/src/main/java/br/com/paymentmanager/service/EnvioBoletoService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class EnvioBoletoService {
@@ -53,7 +54,7 @@ public class EnvioBoletoService {
         List<CodigosDosEnvios> codigosDosEnvios = envioBoletoRepository.findAllCodigosByData(idEmpresa, data)
                 .orElseThrow(() -> new RuntimeException("Não foi possível buscar os codigos das cobrancas"));
 
-        return CodigosDosEnviosDto.converter(codigosDosEnvios);
+        return codigosDosEnvios.stream().map(CodigosDosEnviosDto::new).collect(Collectors.toList());
     }
 
     @Transactional


### PR DESCRIPTION
Este PR contém as alterações necessárias para refatorar a lógica do controller para o service, no contexto do módulo de cobrança. 

As principais mudanças realizadas incluem:
- Mover as operações de criar, alterar e excluir do controller para o respectivo service.
- Atualizar as chamadas do controller para utilizar os métodos correspondentes do service.

Essa refatoração melhora a estrutura do código, separando a lógica de negócio do controller e permitindo reutilização de código em outros componentes.